### PR TITLE
Claude/feat cli auth f03d q

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,10 +449,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chai-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "chai-common",
  "chai-crypto",
  "chai-protocol",
@@ -460,6 +467,7 @@ dependencies = [
  "directories",
  "futures-util",
  "ratatui",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "syntect",
@@ -1250,9 +1258,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1602,6 +1612,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -1848,6 +1859,12 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -2478,6 +2495,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.35",
+ "socket2 0.5.10",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time 1.1.0",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.35",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time 1.1.0",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.10",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2682,6 +2754,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.35",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2689,6 +2763,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.26.4",
  "tower 0.5.2",
  "tower-http 0.6.8",
  "tower-service",
@@ -2696,6 +2771,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -2765,6 +2841,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -2838,6 +2920,7 @@ version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
+ "web-time 1.1.0",
  "zeroize",
 ]
 
@@ -4269,7 +4352,7 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
- "web-time",
+ "web-time 0.2.4",
 ]
 
 [[package]]
@@ -4623,6 +4706,16 @@ name = "web-time"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 
 @theme {
+  /* Premium dark palette - deeper blacks with subtle warmth */
   --color-dark-50: #fafafa;
   --color-dark-100: #f4f4f5;
   --color-dark-200: #e4e4e7;
@@ -13,9 +14,18 @@
   --color-dark-900: #18181b;
   --color-dark-950: #09090b;
 
+  /* Warmer amber-gold accent for premium feel */
+  --color-primary-300: #fcd34d;
   --color-primary-400: #fbbf24;
   --color-primary-500: #f59e0b;
   --color-primary-600: #d97706;
+  --color-primary-700: #b45309;
+
+  /* Accent colors for variety */
+  --color-accent-purple: #a855f7;
+  --color-accent-blue: #3b82f6;
+  --color-accent-emerald: #10b981;
+  --color-accent-rose: #f43f5e;
 }
 
 @layer base {
@@ -23,6 +33,11 @@
     --background: 0 0% 4%;
     --foreground: 0 0% 100%;
     --primary: 38 92% 50%;
+
+    /* Glass effect variables */
+    --glass-bg: rgba(24, 24, 27, 0.7);
+    --glass-border: rgba(63, 63, 70, 0.3);
+    --glass-glow: rgba(251, 191, 36, 0.1);
   }
 
   html {
@@ -35,41 +50,75 @@
     font-feature-settings: 'rlig' 1, 'calt' 1;
   }
 
-  /* Custom scrollbar */
+  /* Custom scrollbar - thinner and more subtle */
   ::-webkit-scrollbar {
-    width: 0.5rem;
+    width: 6px;
   }
 
   ::-webkit-scrollbar-track {
-    background-color: var(--color-dark-900);
+    background-color: transparent;
   }
 
   ::-webkit-scrollbar-thumb {
-    background-color: var(--color-dark-600);
+    background-color: rgba(113, 113, 122, 0.5);
     border-radius: 9999px;
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    background-color: var(--color-dark-500);
+    background-color: rgba(161, 161, 170, 0.5);
+  }
+
+  /* Selection styling */
+  ::selection {
+    background-color: rgba(251, 191, 36, 0.3);
+    color: white;
   }
 }
 
 @layer components {
+  /* Glass morphism cards */
+  .glass {
+    background: var(--glass-bg);
+    backdrop-filter: blur(20px) saturate(180%);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    border: 1px solid var(--glass-border);
+    box-shadow:
+      0 0 0 1px rgba(255, 255, 255, 0.05) inset,
+      0 0 80px -40px var(--glass-glow);
+  }
+
+  .glass-hover {
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .glass-hover:hover {
+    background: rgba(24, 24, 27, 0.8);
+    border-color: rgba(251, 191, 36, 0.2);
+    transform: translateY(-2px);
+    box-shadow:
+      0 0 0 1px rgba(255, 255, 255, 0.08) inset,
+      0 20px 40px -20px rgba(0, 0, 0, 0.5),
+      0 0 80px -20px var(--glass-glow);
+  }
+
+  /* Premium buttons */
   .btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border-radius: 0.5rem;
-    padding: 0.5rem 1rem;
+    gap: 0.5rem;
+    border-radius: 0.75rem;
+    padding: 0.625rem 1.25rem;
     font-size: 0.875rem;
     font-weight: 500;
-    transition: colors 0.15s;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    position: relative;
+    overflow: hidden;
   }
 
   .btn:focus-visible {
     outline: none;
-    ring: 2px;
-    ring-color: var(--color-primary-500);
+    box-shadow: 0 0 0 2px var(--color-dark-950), 0 0 0 4px var(--color-primary-500);
   }
 
   .btn:disabled {
@@ -78,51 +127,308 @@
   }
 
   .btn-primary {
-    background-color: var(--color-primary-500);
-    color: white;
+    background: linear-gradient(135deg, var(--color-primary-500) 0%, var(--color-primary-600) 100%);
+    color: black;
+    font-weight: 600;
+    box-shadow: 0 4px 14px -3px rgba(245, 158, 11, 0.4);
   }
 
   .btn-primary:hover {
-    background-color: var(--color-primary-600);
+    background: linear-gradient(135deg, var(--color-primary-400) 0%, var(--color-primary-500) 100%);
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px -3px rgba(245, 158, 11, 0.5);
+  }
+
+  .btn-primary:active {
+    transform: translateY(0);
+    box-shadow: 0 2px 8px -2px rgba(245, 158, 11, 0.4);
+  }
+
+  /* Shimmer effect on primary buttons */
+  .btn-primary::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      rgba(255, 255, 255, 0.2),
+      transparent
+    );
+    transition: 0.5s;
+  }
+
+  .btn-primary:hover::after {
+    left: 100%;
   }
 
   .btn-secondary {
-    background-color: var(--color-dark-800);
+    background: rgba(39, 39, 42, 0.8);
     color: white;
+    border: 1px solid rgba(63, 63, 70, 0.5);
   }
 
   .btn-secondary:hover {
-    background-color: var(--color-dark-700);
+    background: rgba(63, 63, 70, 0.8);
+    border-color: rgba(113, 113, 122, 0.5);
+  }
+
+  .btn-ghost {
+    color: var(--color-dark-400);
   }
 
   .btn-ghost:hover {
-    background-color: var(--color-dark-800);
-  }
-
-  .input {
-    width: 100%;
-    border-radius: 0.5rem;
-    border: 1px solid var(--color-dark-700);
-    background-color: var(--color-dark-900);
-    padding: 0.5rem 1rem;
+    background: rgba(39, 39, 42, 0.5);
     color: white;
   }
 
+  /* Premium inputs */
+  .input {
+    width: 100%;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(63, 63, 70, 0.5);
+    background: rgba(24, 24, 27, 0.8);
+    padding: 0.75rem 1rem;
+    color: white;
+    font-size: 0.9375rem;
+    transition: all 0.2s ease;
+  }
+
   .input::placeholder {
-    color: var(--color-dark-400);
+    color: var(--color-dark-500);
+  }
+
+  .input:hover {
+    border-color: rgba(113, 113, 122, 0.5);
   }
 
   .input:focus {
     border-color: var(--color-primary-500);
     outline: none;
-    box-shadow: 0 0 0 1px var(--color-primary-500);
+    box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.15);
+    background: rgba(24, 24, 27, 1);
   }
 
+  /* Premium cards */
   .card {
-    border-radius: 0.75rem;
-    border: 1px solid var(--color-dark-800);
-    background-color: var(--color-dark-900);
+    border-radius: 1rem;
+    border: 1px solid rgba(63, 63, 70, 0.3);
+    background: rgba(24, 24, 27, 0.6);
+    backdrop-filter: blur(10px);
     padding: 1.5rem;
+  }
+
+  /* Message bubble styles */
+  .message-bubble {
+    border-radius: 1.25rem;
+    padding: 0.75rem 1rem;
+    max-width: 75%;
+    position: relative;
+    animation: messageSlide 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .message-bubble-self {
+    background: linear-gradient(135deg, var(--color-primary-500) 0%, #ea580c 100%);
+    color: black;
+    border-bottom-right-radius: 0.375rem;
+    box-shadow: 0 4px 15px -3px rgba(245, 158, 11, 0.3);
+  }
+
+  .message-bubble-other {
+    background: rgba(39, 39, 42, 0.8);
+    color: white;
+    border: 1px solid rgba(63, 63, 70, 0.3);
+    border-bottom-left-radius: 0.375rem;
+  }
+
+  @keyframes messageSlide {
+    from {
+      opacity: 0;
+      transform: translateY(10px) scale(0.98);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  /* Conversation list item */
+  .conversation-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.75rem;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    position: relative;
+  }
+
+  .conversation-item:hover {
+    background: rgba(39, 39, 42, 0.5);
+  }
+
+  .conversation-item.active {
+    background: rgba(251, 191, 36, 0.1);
+    border: 1px solid rgba(251, 191, 36, 0.2);
+  }
+
+  .conversation-item.active::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 3px;
+    height: 60%;
+    background: var(--color-primary-500);
+    border-radius: 0 2px 2px 0;
+  }
+
+  /* Avatar with online indicator */
+  .avatar {
+    position: relative;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    font-size: 0.9375rem;
+    background: linear-gradient(135deg, var(--color-dark-700) 0%, var(--color-dark-800) 100%);
+    flex-shrink: 0;
+  }
+
+  .avatar-online::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 0.75rem;
+    height: 0.75rem;
+    background: var(--color-accent-emerald);
+    border: 2px solid var(--color-dark-950);
+    border-radius: 50%;
+    animation: pulse 2s infinite;
+  }
+
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.7; }
+  }
+
+  /* Unread badge */
+  .unread-badge {
+    min-width: 1.25rem;
+    height: 1.25rem;
+    padding: 0 0.375rem;
+    background: var(--color-primary-500);
+    color: black;
+    font-size: 0.75rem;
+    font-weight: 600;
+    border-radius: 9999px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* Typing indicator */
+  .typing-indicator {
+    display: flex;
+    gap: 4px;
+    padding: 8px 12px;
+  }
+
+  .typing-indicator span {
+    width: 6px;
+    height: 6px;
+    background: var(--color-dark-500);
+    border-radius: 50%;
+    animation: typingBounce 1.4s infinite ease-in-out both;
+  }
+
+  .typing-indicator span:nth-child(1) { animation-delay: 0s; }
+  .typing-indicator span:nth-child(2) { animation-delay: 0.2s; }
+  .typing-indicator span:nth-child(3) { animation-delay: 0.4s; }
+
+  @keyframes typingBounce {
+    0%, 80%, 100% {
+      transform: scale(0.8);
+      opacity: 0.5;
+    }
+    40% {
+      transform: scale(1);
+      opacity: 1;
+    }
+  }
+
+  /* Sidebar */
+  .sidebar {
+    background: rgba(9, 9, 11, 0.95);
+    backdrop-filter: blur(20px);
+    border-right: 1px solid rgba(39, 39, 42, 0.5);
+  }
+
+  /* Premium header */
+  .header {
+    background: rgba(9, 9, 11, 0.8);
+    backdrop-filter: blur(20px);
+    border-bottom: 1px solid rgba(39, 39, 42, 0.3);
+  }
+
+  /* Floating action button */
+  .fab {
+    width: 3.5rem;
+    height: 3.5rem;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--color-primary-500) 0%, var(--color-primary-600) 100%);
+    color: black;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow:
+      0 4px 14px -3px rgba(245, 158, 11, 0.5),
+      0 0 40px -10px rgba(245, 158, 11, 0.3);
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    cursor: pointer;
+  }
+
+  .fab:hover {
+    transform: scale(1.1);
+    box-shadow:
+      0 6px 20px -3px rgba(245, 158, 11, 0.6),
+      0 0 60px -10px rgba(245, 158, 11, 0.4);
+  }
+
+  /* Modal/Dialog */
+  .modal-backdrop {
+    background: rgba(0, 0, 0, 0.8);
+    backdrop-filter: blur(8px);
+  }
+
+  .modal-content {
+    background: rgba(24, 24, 27, 0.95);
+    backdrop-filter: blur(20px);
+    border: 1px solid rgba(63, 63, 70, 0.3);
+    border-radius: 1.25rem;
+    box-shadow:
+      0 25px 50px -12px rgba(0, 0, 0, 0.5),
+      0 0 100px -20px var(--glass-glow);
+  }
+
+  /* Tooltip */
+  .tooltip {
+    background: rgba(39, 39, 42, 0.95);
+    border: 1px solid rgba(63, 63, 70, 0.5);
+    border-radius: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.8125rem;
+    color: var(--color-dark-200);
+    box-shadow: 0 4px 12px -2px rgba(0, 0, 0, 0.3);
   }
 }
 
@@ -131,21 +437,122 @@
     text-wrap: balance;
   }
 
-  /* Glow pulse animation for hero logo */
+  /* Gradient text */
+  .gradient-text {
+    background: linear-gradient(135deg, var(--color-primary-400) 0%, var(--color-primary-500) 50%, #ea580c 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  /* Animated gradient background */
+  .gradient-bg {
+    background: linear-gradient(
+      135deg,
+      var(--color-dark-950) 0%,
+      #0c0c0f 50%,
+      var(--color-dark-950) 100%
+    );
+    background-size: 200% 200%;
+    animation: gradientMove 15s ease infinite;
+  }
+
+  @keyframes gradientMove {
+    0%, 100% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
+  }
+
+  /* Mesh gradient overlay */
+  .mesh-gradient {
+    position: relative;
+  }
+
+  .mesh-gradient::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background:
+      radial-gradient(ellipse at 20% 20%, rgba(251, 191, 36, 0.08) 0%, transparent 50%),
+      radial-gradient(ellipse at 80% 80%, rgba(168, 85, 247, 0.05) 0%, transparent 50%),
+      radial-gradient(ellipse at 40% 60%, rgba(59, 130, 246, 0.03) 0%, transparent 50%);
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  /* Glow effects */
+  .glow-amber {
+    box-shadow: 0 0 40px -10px rgba(251, 191, 36, 0.5);
+  }
+
   .glow-pulse {
     animation: glowPulse 3s ease-in-out infinite;
   }
 
   @keyframes glowPulse {
     0%, 100% {
-      box-shadow: 0 25px 50px -12px rgba(245, 158, 11, 0.25);
+      box-shadow: 0 0 40px -10px rgba(245, 158, 11, 0.4);
     }
     50% {
-      box-shadow: 0 25px 50px -12px rgba(245, 158, 11, 0.45);
+      box-shadow: 0 0 60px -10px rgba(245, 158, 11, 0.6);
     }
   }
 
-  /* Staggered entrance for feature cards */
+  /* Staggered entrance animations */
+  .fade-in {
+    animation: fadeIn 0.5s ease-out;
+  }
+
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  .slide-up {
+    animation: slideUp 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  @keyframes slideUp {
+    from {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .slide-in-right {
+    animation: slideInRight 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  @keyframes slideInRight {
+    from {
+      opacity: 0;
+      transform: translateX(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  .scale-in {
+    animation: scaleIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  @keyframes scaleIn {
+    from {
+      opacity: 0;
+      transform: scale(0.95);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  /* Feature card animation */
   .feature-card {
     animation: fadeInUp 0.6s ease-out backwards;
   }
@@ -165,6 +572,7 @@
   .typing-cursor::after {
     content: '|';
     animation: blink 1s step-end infinite;
+    color: var(--color-primary-500);
   }
 
   @keyframes blink {
@@ -202,5 +610,78 @@
       transform: rotateX(0);
       opacity: 1;
     }
+  }
+
+  /* Loading spinner */
+  .spinner {
+    width: 1.25rem;
+    height: 1.25rem;
+    border: 2px solid transparent;
+    border-top-color: currentColor;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+  }
+
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+
+  /* Smooth appear for messages */
+  .message-appear {
+    animation: messageAppear 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  @keyframes messageAppear {
+    from {
+      opacity: 0;
+      transform: translateY(8px) scale(0.98);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  /* Hover lift effect */
+  .hover-lift {
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .hover-lift:hover {
+    transform: translateY(-2px);
+  }
+
+  /* Focus ring */
+  .focus-ring:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--color-dark-950), 0 0 0 4px var(--color-primary-500);
+  }
+
+  /* Divider line */
+  .divider {
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--color-dark-700), transparent);
+  }
+
+  /* Noise texture overlay */
+  .noise {
+    position: relative;
+  }
+
+  .noise::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%' height='100%' filter='url(%23noise)'/%3E%3C/svg%3E");
+    opacity: 0.03;
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  /* Subtle grain */
+  .grain {
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='grain'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23grain)'/%3E%3C/svg%3E");
+    background-repeat: repeat;
+    background-size: 512px 512px;
   }
 }

--- a/crates/chai-cli/Cargo.toml
+++ b/crates/chai-cli/Cargo.toml
@@ -31,6 +31,12 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 
+# HTTP client for auth
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+
+# Base64 encoding
+base64 = "0.22"
+
 # Config
 directories = "5.0"
 toml = "0.8"

--- a/crates/chai-cli/src/auth.rs
+++ b/crates/chai-cli/src/auth.rs
@@ -1,0 +1,227 @@
+//! Authentication module for identity key-based auth.
+//!
+//! Implements passwordless authentication using Ed25519 signatures.
+
+use crate::config::Config;
+use anyhow::{anyhow, Result};
+use chai_crypto::{
+    keys::IdentityKeyPair,
+    mnemonic::{derive_identity_from_words, generate_mnemonic, validate_mnemonic, MnemonicStrength},
+};
+use serde::{Deserialize, Serialize};
+
+/// HTTP client for auth API.
+pub struct AuthClient {
+    client: reqwest::Client,
+    base_url: String,
+}
+
+// Request/Response types matching the server
+
+#[derive(Debug, Serialize)]
+struct RegisterRequest {
+    username: String,
+    identity_key: Vec<u8>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegisterResponse {
+    user_id: String,
+    session_token: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ChallengeRequest {
+    username: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChallengeResponse {
+    challenge: Vec<u8>,
+    expires_at: i64,
+}
+
+#[derive(Debug, Serialize)]
+struct VerifyRequest {
+    username: String,
+    challenge: Vec<u8>,
+    signature: Vec<u8>,
+}
+
+#[derive(Debug, Deserialize)]
+struct VerifyResponse {
+    user_id: String,
+    session_token: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+impl AuthClient {
+    /// Create a new auth client.
+    pub fn new(base_url: &str) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            base_url: base_url.to_string(),
+        }
+    }
+
+    /// Register a new user with username and identity key.
+    pub async fn register(
+        &self,
+        username: &str,
+        identity: &IdentityKeyPair,
+    ) -> Result<(String, String)> {
+        let public_key = identity.public_key().to_bytes().to_vec();
+
+        let resp = self
+            .client
+            .post(format!("{}/auth/identity/register", self.base_url))
+            .json(&RegisterRequest {
+                username: username.to_string(),
+                identity_key: public_key,
+            })
+            .send()
+            .await?;
+
+        if resp.status().is_success() {
+            let data: RegisterResponse = resp.json().await?;
+            Ok((data.user_id, data.session_token))
+        } else {
+            let err: ErrorResponse = resp.json().await.unwrap_or(ErrorResponse {
+                error: "Unknown error".into(),
+            });
+            Err(anyhow!("Registration failed: {}", err.error))
+        }
+    }
+
+    /// Login with challenge-response signature.
+    pub async fn login(
+        &self,
+        username: &str,
+        identity: &IdentityKeyPair,
+    ) -> Result<(String, String)> {
+        // Step 1: Request challenge
+        let resp = self
+            .client
+            .post(format!("{}/auth/identity/challenge", self.base_url))
+            .json(&ChallengeRequest {
+                username: username.to_string(),
+            })
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let err: ErrorResponse = resp.json().await.unwrap_or(ErrorResponse {
+                error: "Unknown error".into(),
+            });
+            return Err(anyhow!("Challenge request failed: {}", err.error));
+        }
+
+        let challenge_resp: ChallengeResponse = resp.json().await?;
+
+        // Step 2: Sign the challenge
+        let signature = identity.sign(&challenge_resp.challenge);
+
+        // Step 3: Verify signature
+        let resp = self
+            .client
+            .post(format!("{}/auth/identity/verify", self.base_url))
+            .json(&VerifyRequest {
+                username: username.to_string(),
+                challenge: challenge_resp.challenge,
+                signature,
+            })
+            .send()
+            .await?;
+
+        if resp.status().is_success() {
+            let data: VerifyResponse = resp.json().await?;
+            Ok((data.user_id, data.session_token))
+        } else {
+            let err: ErrorResponse = resp.json().await.unwrap_or(ErrorResponse {
+                error: "Unknown error".into(),
+            });
+            Err(anyhow!("Login failed: {}", err.error))
+        }
+    }
+}
+
+/// Generate a new 24-word mnemonic.
+pub fn new_mnemonic() -> String {
+    generate_mnemonic(MnemonicStrength::Words24)
+}
+
+/// Validate a mnemonic phrase.
+pub fn is_valid_mnemonic(words: &str) -> bool {
+    validate_mnemonic(words)
+}
+
+/// Derive identity from mnemonic.
+pub fn identity_from_mnemonic(words: &str) -> Result<IdentityKeyPair> {
+    derive_identity_from_words(words, "")
+        .map_err(|e| anyhow!("Invalid mnemonic: {:?}", e))
+}
+
+/// Perform registration flow.
+pub async fn register_flow(
+    config: &mut Config,
+    username: &str,
+    mnemonic: &str,
+) -> Result<()> {
+    // Derive identity from mnemonic
+    let identity = identity_from_mnemonic(mnemonic)?;
+
+    // Register with server
+    let client = AuthClient::new(&config.server_url);
+    let (user_id, session_token) = client.register(username, &identity).await?;
+
+    // Save to config
+    config.username = Some(username.to_string());
+    config.user_id = Some(user_id);
+    config.session_token = Some(session_token);
+    config.set_identity(&identity);
+    config.save()?;
+
+    Ok(())
+}
+
+/// Perform login flow with existing mnemonic.
+pub async fn login_flow(
+    config: &mut Config,
+    username: &str,
+    mnemonic: &str,
+) -> Result<()> {
+    // Derive identity from mnemonic
+    let identity = identity_from_mnemonic(mnemonic)?;
+
+    // Login with server
+    let client = AuthClient::new(&config.server_url);
+    let (user_id, session_token) = client.login(username, &identity).await?;
+
+    // Save to config
+    config.username = Some(username.to_string());
+    config.user_id = Some(user_id);
+    config.session_token = Some(session_token);
+    config.set_identity(&identity);
+    config.save()?;
+
+    Ok(())
+}
+
+/// Login with stored identity key (skip mnemonic entry).
+pub async fn login_with_stored_identity(config: &mut Config) -> Result<()> {
+    let username = config.username.as_ref().ok_or_else(|| anyhow!("No username stored"))?;
+    let identity = config.get_identity().ok_or_else(|| anyhow!("No identity key stored"))?;
+
+    let client = AuthClient::new(&config.server_url);
+    let (user_id, session_token) = client.login(username, &identity).await?;
+
+    config.user_id = Some(user_id);
+    config.session_token = Some(session_token);
+    config.save()?;
+
+    Ok(())
+}

--- a/crates/chai-cli/src/config.rs
+++ b/crates/chai-cli/src/config.rs
@@ -1,14 +1,18 @@
 //! CLI configuration.
 
 use anyhow::Result;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use chai_crypto::keys::IdentityKeyPair;
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
-    /// Server URL.
+    /// Server base URL (for API requests).
     pub server_url: String,
+    /// WebSocket URL (for real-time messaging).
+    pub ws_url: String,
     /// Username.
     pub username: Option<String>,
     /// User ID (after login).
@@ -17,6 +21,9 @@ pub struct Config {
     /// Session token (after login).
     #[serde(default)]
     pub session_token: Option<String>,
+    /// Identity key bytes (32 bytes, base64 encoded).
+    #[serde(default)]
+    pub identity_key: Option<String>,
     /// Theme.
     pub theme: Theme,
 }
@@ -34,10 +41,12 @@ pub struct Theme {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            server_url: "ws://localhost:8080/ws".into(),
+            server_url: "http://localhost:8080".into(),
+            ws_url: "ws://localhost:8080/ws".into(),
             username: None,
             user_id: None,
             session_token: None,
+            identity_key: None,
             theme: Theme::default(),
         }
     }
@@ -86,5 +95,36 @@ impl Config {
             }
         }
         Ok(())
+    }
+
+    /// Check if user is authenticated.
+    pub fn is_authenticated(&self) -> bool {
+        self.session_token.is_some() && self.user_id.is_some() && self.identity_key.is_some()
+    }
+
+    /// Get the identity key pair if stored.
+    pub fn get_identity(&self) -> Option<IdentityKeyPair> {
+        self.identity_key.as_ref().and_then(|key_b64| {
+            let bytes = BASE64.decode(key_b64).ok()?;
+            if bytes.len() != 32 {
+                return None;
+            }
+            let key_bytes: [u8; 32] = bytes.try_into().ok()?;
+            Some(IdentityKeyPair::from_bytes(&key_bytes))
+        })
+    }
+
+    /// Store the identity key pair.
+    pub fn set_identity(&mut self, identity: &IdentityKeyPair) {
+        let bytes = identity.to_bytes();
+        self.identity_key = Some(BASE64.encode(bytes));
+    }
+
+    /// Clear all auth data.
+    pub fn logout(&mut self) {
+        self.username = None;
+        self.user_id = None;
+        self.session_token = None;
+        self.identity_key = None;
     }
 }

--- a/crates/chai-cli/src/main.rs
+++ b/crates/chai-cli/src/main.rs
@@ -1,6 +1,7 @@
 //! Chai.im terminal client.
 #![allow(dead_code)]
 
+mod auth;
 mod config;
 mod error;
 mod network;

--- a/crates/chai-cli/src/tui/app.rs
+++ b/crates/chai-cli/src/tui/app.rs
@@ -1,12 +1,18 @@
-//! Application state.
+//! Application state with typing indicators and read receipts.
 
 use crate::config::Config;
 use crate::network::client::Client;
 use anyhow::Result;
-use chai_common::{uuid, ConversationId, UserId};
+use chai_common::{uuid, ConversationId, MessageId, UserId};
 use chai_protocol::{ClientMessage, MessageType, ServerMessage};
 use crossterm::event::{KeyCode, KeyEvent};
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// Typing indicator timeout (5 seconds).
+const TYPING_TIMEOUT: Duration = Duration::from_secs(5);
+/// Debounce interval for sending typing indicators.
+const TYPING_DEBOUNCE: Duration = Duration::from_secs(3);
 
 /// Input mode for the application.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -19,13 +25,35 @@ pub enum InputMode {
     Command,
 }
 
+/// Message delivery status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageStatus {
+    Sending,
+    Sent,
+    Delivered,
+    Read,
+}
+
+impl MessageStatus {
+    pub fn icon(&self) -> &'static str {
+        match self {
+            MessageStatus::Sending => "○",
+            MessageStatus::Sent => "✓",
+            MessageStatus::Delivered => "✓✓",
+            MessageStatus::Read => "✓✓",
+        }
+    }
+}
+
 /// A chat message.
 #[derive(Debug, Clone)]
 pub struct Message {
+    pub id: Option<String>,
     pub sender: String,
     pub content: String,
     pub timestamp: String,
     pub is_self: bool,
+    pub status: MessageStatus,
 }
 
 /// A conversation in the sidebar.
@@ -36,6 +64,13 @@ pub struct Conversation {
     pub last_message: Option<String>,
     pub unread_count: u32,
     pub online: bool,
+    pub typing: bool,
+}
+
+/// Typing state for a user.
+struct TypingState {
+    user_id: String,
+    started_at: Instant,
 }
 
 /// Application state.
@@ -64,15 +99,21 @@ pub struct App {
     client: Option<Client>,
     /// Current user ID.
     pub user_id: Option<String>,
+    /// Users currently typing in each conversation.
+    typing_states: HashMap<String, Vec<TypingState>>,
+    /// When we last sent a typing indicator.
+    last_typing_sent: Option<Instant>,
+    /// Whether we're currently in "typing" state.
+    is_typing: bool,
 }
 
 impl App {
     pub fn new(config: Config) -> Self {
         let user_id = config.user_id.clone();
         let status = if config.session_token.is_some() {
-            "Ready to connect".into()
+            "Ready to connect. Press ':c' to connect".into()
         } else {
-            "Not logged in".into()
+            "Not logged in. Use ':login' to sign in".into()
         };
 
         Self {
@@ -88,6 +129,9 @@ impl App {
             connected: false,
             client: None,
             user_id,
+            typing_states: HashMap::new(),
+            last_typing_sent: None,
+            is_typing: false,
         }
     }
 
@@ -101,12 +145,27 @@ impl App {
         &[]
     }
 
+    /// Get typing users for the current conversation.
+    pub fn typing_users(&self) -> Vec<&str> {
+        if let Some(conv) = self.conversations.get(self.selected_conversation) {
+            if let Some(states) = self.typing_states.get(&conv.id) {
+                return states.iter().map(|s| s.user_id.as_str()).collect();
+            }
+        }
+        Vec::new()
+    }
+
+    /// Check if anyone is typing in the current conversation.
+    pub fn is_someone_typing(&self) -> bool {
+        !self.typing_users().is_empty()
+    }
+
     /// Connect to the server.
     pub async fn connect(&mut self) -> Result<()> {
         let token = match &self.config.session_token {
             Some(t) => t.clone(),
             None => {
-                self.status = "No session token - please login first".into();
+                self.status = "No session token - use ':login' first".into();
                 return Ok(());
             }
         };
@@ -120,7 +179,7 @@ impl App {
             Ok(client) => {
                 self.client = Some(client);
                 self.connected = true;
-                self.status = "Connected".into();
+                self.status = "Connected ●".into();
             }
             Err(e) => {
                 self.status = format!("Connection failed: {}", e);
@@ -132,6 +191,10 @@ impl App {
 
     /// Disconnect from the server.
     pub fn disconnect(&mut self) {
+        // Send typing stop if we were typing
+        if self.is_typing {
+            self.send_typing_stop();
+        }
         self.client = None;
         self.connected = false;
         self.status = "Disconnected".into();
@@ -159,20 +222,26 @@ impl App {
             KeyCode::Char('j') | KeyCode::Down => {
                 if self.selected_conversation < self.conversations.len().saturating_sub(1) {
                     self.selected_conversation += 1;
+                    self.mark_conversation_read();
                 }
             }
             KeyCode::Char('k') | KeyCode::Up => {
                 if self.selected_conversation > 0 {
                     self.selected_conversation -= 1;
+                    self.mark_conversation_read();
                 }
             }
             KeyCode::Char('g') => {
-                // Go to top
                 self.selected_conversation = 0;
+                self.mark_conversation_read();
             }
             KeyCode::Char('G') => {
-                // Go to bottom
                 self.selected_conversation = self.conversations.len().saturating_sub(1);
+                self.mark_conversation_read();
+            }
+            KeyCode::Enter => {
+                // Mark current conversation as read on enter
+                self.mark_conversation_read();
             }
             _ => {}
         }
@@ -182,20 +251,34 @@ impl App {
         match key.code {
             KeyCode::Esc => {
                 self.input_mode = InputMode::Normal;
+                // Send typing stop when exiting edit mode
+                if self.is_typing {
+                    self.send_typing_stop();
+                }
             }
             KeyCode::Enter => {
                 if !self.input.is_empty() {
+                    // Send typing stop before sending message
+                    if self.is_typing {
+                        self.send_typing_stop();
+                    }
                     self.send_message();
                 }
             }
             KeyCode::Char(c) => {
                 self.input.insert(self.cursor_position, c);
                 self.cursor_position += 1;
+                // Send typing indicator
+                self.maybe_send_typing_start();
             }
             KeyCode::Backspace => {
                 if self.cursor_position > 0 {
                     self.cursor_position -= 1;
                     self.input.remove(self.cursor_position);
+                }
+                // If input is now empty, send typing stop
+                if self.input.is_empty() && self.is_typing {
+                    self.send_typing_stop();
                 }
             }
             KeyCode::Delete => {
@@ -248,6 +331,116 @@ impl App {
         }
     }
 
+    /// Maybe send typing start indicator (debounced).
+    fn maybe_send_typing_start(&mut self) {
+        let should_send = match self.last_typing_sent {
+            None => true,
+            Some(last) => last.elapsed() >= TYPING_DEBOUNCE,
+        };
+
+        if should_send && self.connected {
+            self.send_typing_start();
+        }
+    }
+
+    /// Send typing start indicator.
+    fn send_typing_start(&mut self) {
+        if let Some(conv) = self.conversations.get(self.selected_conversation) {
+            let recipient_uuid = conv
+                .id
+                .strip_prefix("conv_")
+                .and_then(|s| uuid::Uuid::parse_str(s).ok())
+                .unwrap_or_else(uuid::Uuid::nil);
+
+            let msg = ClientMessage::TypingStart {
+                recipient_id: UserId(recipient_uuid),
+                conversation_id: ConversationId(recipient_uuid),
+            };
+
+            if let Some(client) = &self.client {
+                let client = client.clone();
+                tokio::spawn(async move {
+                    let _ = client.send(msg).await;
+                });
+            }
+
+            self.last_typing_sent = Some(Instant::now());
+            self.is_typing = true;
+        }
+    }
+
+    /// Send typing stop indicator.
+    fn send_typing_stop(&mut self) {
+        if let Some(conv) = self.conversations.get(self.selected_conversation) {
+            let recipient_uuid = conv
+                .id
+                .strip_prefix("conv_")
+                .and_then(|s| uuid::Uuid::parse_str(s).ok())
+                .unwrap_or_else(uuid::Uuid::nil);
+
+            let msg = ClientMessage::TypingStop {
+                recipient_id: UserId(recipient_uuid),
+                conversation_id: ConversationId(recipient_uuid),
+            };
+
+            if let Some(client) = &self.client {
+                let client = client.clone();
+                tokio::spawn(async move {
+                    let _ = client.send(msg).await;
+                });
+            }
+
+            self.is_typing = false;
+            self.last_typing_sent = None;
+        }
+    }
+
+    /// Mark current conversation as read.
+    fn mark_conversation_read(&mut self) {
+        if let Some(conv) = self.conversations.get_mut(self.selected_conversation) {
+            if conv.unread_count > 0 {
+                conv.unread_count = 0;
+
+                // Send read receipts
+                let recipient_uuid = conv
+                    .id
+                    .strip_prefix("conv_")
+                    .and_then(|s| uuid::Uuid::parse_str(s).ok())
+                    .unwrap_or_else(uuid::Uuid::nil);
+
+                // Get unread message IDs
+                let message_ids: Vec<MessageId> = self
+                    .conversation_messages
+                    .get(&conv.id)
+                    .map(|msgs| {
+                        msgs.iter()
+                            .filter(|m| !m.is_self)
+                            .filter_map(|m| {
+                                m.id.as_ref()
+                                    .and_then(|id| uuid::Uuid::parse_str(id).ok())
+                                    .map(MessageId)
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                if !message_ids.is_empty() {
+                    let msg = ClientMessage::MarkRead {
+                        conversation_id: ConversationId(recipient_uuid),
+                        message_ids,
+                    };
+
+                    if let Some(client) = &self.client {
+                        let client = client.clone();
+                        tokio::spawn(async move {
+                            let _ = client.send(msg).await;
+                        });
+                    }
+                }
+            }
+        }
+    }
+
     fn send_message(&mut self) {
         let content = std::mem::take(&mut self.input);
         self.cursor_position = 0;
@@ -265,21 +458,25 @@ impl App {
             }
         };
 
+        // Generate message ID
+        let msg_id = uuid::Uuid::new_v4().to_string();
+
         // Add message to local list
         let messages = self
             .conversation_messages
             .entry(conv.id.clone())
             .or_default();
         messages.push(Message {
+            id: Some(msg_id.clone()),
             sender: "You".into(),
             content: content.clone(),
             timestamp: chrono_lite_timestamp(),
             is_self: true,
+            status: MessageStatus::Sending,
         });
 
         // Send via WebSocket if connected
         if let Some(client) = &self.client {
-            // Parse recipient as UUID (conversation ID is conv_{user_id})
             let recipient_uuid = conv
                 .id
                 .strip_prefix("conv_")
@@ -308,51 +505,53 @@ impl App {
                 // Will be handled by main loop
             }
             "connect" | "c" => {
-                // Connection will be handled in tick()
-                self.status = "Use :connect command, then wait...".into();
+                self.status = "Connecting...".into();
             }
             "disconnect" | "dc" => {
                 self.disconnect();
             }
+            "help" | "h" => {
+                self.status = ":c connect | :dc disconnect | :chat <user> | :q quit".into();
+            }
             _ if cmd.starts_with("chat ") => {
-                // Start a new conversation: :chat username
                 let username = cmd.strip_prefix("chat ").unwrap().trim();
                 if !username.is_empty() {
                     self.start_conversation(username.to_string());
                 }
             }
             _ => {
-                self.status = format!("Unknown command: {}", cmd);
+                self.status = format!("Unknown: {} (try :help)", cmd);
             }
         }
     }
 
     /// Start a new conversation with a user.
     fn start_conversation(&mut self, username: String) {
-        // Check if conversation already exists
         if let Some(idx) = self.conversations.iter().position(|c| c.name == username) {
             self.selected_conversation = idx;
             return;
         }
 
-        // Create new conversation
         let conv = Conversation {
             id: format!("conv_{}", username),
             name: username.clone(),
             last_message: None,
             unread_count: 0,
             online: false,
+            typing: false,
         };
 
         self.conversations.push(conv);
         self.selected_conversation = self.conversations.len() - 1;
-        self.status = format!("Started conversation with {}", username);
+        self.status = format!("Chat with {}", username);
     }
 
     /// Process network events.
     pub async fn tick(&mut self) -> Result<()> {
+        // Clean up expired typing indicators
+        self.cleanup_typing_indicators();
+
         // Process incoming messages from WebSocket
-        // Collect messages first to avoid borrow issues
         let messages: Vec<_> = if let Some(client) = &self.client {
             let mut msgs = Vec::new();
             while let Some(msg) = client.try_recv() {
@@ -369,20 +568,41 @@ impl App {
         Ok(())
     }
 
+    /// Clean up expired typing indicators.
+    fn cleanup_typing_indicators(&mut self) {
+        for (_conv_id, states) in self.typing_states.iter_mut() {
+            states.retain(|s| s.started_at.elapsed() < TYPING_TIMEOUT);
+        }
+
+        // Update conversation typing status
+        for conv in &mut self.conversations {
+            conv.typing = self
+                .typing_states
+                .get(&conv.id)
+                .map(|s| !s.is_empty())
+                .unwrap_or(false);
+        }
+    }
+
     /// Handle incoming server message.
     fn handle_server_message(&mut self, msg: ServerMessage) {
         match msg {
             ServerMessage::Message {
+                id,
                 sender_id,
                 conversation_id,
                 ciphertext,
                 timestamp,
                 ..
             } => {
-                // Decode message content (plaintext for now - TODO: decrypt)
                 let content = String::from_utf8_lossy(&ciphertext).to_string();
                 let conv_id = format!("conv_{}", conversation_id.0);
                 let sender_name = sender_id.0.to_string();
+
+                // Clear typing indicator for this sender
+                if let Some(states) = self.typing_states.get_mut(&conv_id) {
+                    states.retain(|s| s.user_id != sender_name);
+                }
 
                 // Find or create conversation
                 let conv_exists = self.conversations.iter().any(|c| c.id == conv_id);
@@ -393,13 +613,14 @@ impl App {
                         last_message: Some(content.clone()),
                         unread_count: 1,
                         online: true,
+                        typing: false,
                     });
                 } else {
-                    // Update existing conversation
                     for conv in &mut self.conversations {
                         if conv.id == conv_id {
                             conv.last_message = Some(content.clone());
                             conv.unread_count += 1;
+                            conv.typing = false;
                         }
                     }
                 }
@@ -407,17 +628,64 @@ impl App {
                 // Add message
                 let messages = self.conversation_messages.entry(conv_id).or_default();
                 messages.push(Message {
+                    id: Some(id.0.to_string()),
                     sender: sender_name,
                     content,
                     timestamp: format_timestamp(timestamp),
                     is_self: false,
+                    status: MessageStatus::Delivered,
                 });
             }
-            ServerMessage::MessageSent { .. } => {
-                // Message was delivered to server
+            ServerMessage::MessageSent { message_id, .. } => {
+                // Update message status to Sent
+                self.update_message_status(&message_id.0.to_string(), MessageStatus::Sent);
             }
-            ServerMessage::MessageDelivered { .. } => {
-                // Message was delivered to recipient
+            ServerMessage::MessageDelivered { message_id, .. } => {
+                self.update_message_status(&message_id.0.to_string(), MessageStatus::Delivered);
+            }
+            ServerMessage::MessageRead { message_id, .. } => {
+                self.update_message_status(&message_id.0.to_string(), MessageStatus::Read);
+            }
+            ServerMessage::TypingIndicator {
+                user_id,
+                conversation_id,
+                is_typing,
+            } => {
+                let conv_id = format!("conv_{}", conversation_id.0);
+                let user_name = user_id.0.to_string();
+
+                if is_typing {
+                    // Add/refresh typing state
+                    let states = self.typing_states.entry(conv_id.clone()).or_default();
+                    states.retain(|s| s.user_id != user_name);
+                    states.push(TypingState {
+                        user_id: user_name,
+                        started_at: Instant::now(),
+                    });
+
+                    // Update conversation
+                    for conv in &mut self.conversations {
+                        if conv.id == conv_id {
+                            conv.typing = true;
+                        }
+                    }
+                } else {
+                    // Remove typing state
+                    if let Some(states) = self.typing_states.get_mut(&conv_id) {
+                        states.retain(|s| s.user_id != user_name);
+                    }
+
+                    // Update conversation
+                    for conv in &mut self.conversations {
+                        if conv.id == conv_id {
+                            conv.typing = self
+                                .typing_states
+                                .get(&conv_id)
+                                .map(|s| !s.is_empty())
+                                .unwrap_or(false);
+                        }
+                    }
+                }
             }
             ServerMessage::Error { message, .. } => {
                 self.status = format!("Error: {}", message);
@@ -425,7 +693,6 @@ impl App {
             ServerMessage::PresenceUpdate {
                 user_id, status, ..
             } => {
-                // Update user presence
                 use chai_protocol::UserStatus;
                 let user_name = user_id.0.to_string();
                 let online = matches!(status, UserStatus::Active | UserStatus::Away);
@@ -436,6 +703,18 @@ impl App {
                 }
             }
             _ => {}
+        }
+    }
+
+    /// Update a message's delivery status.
+    fn update_message_status(&mut self, msg_id: &str, status: MessageStatus) {
+        for messages in self.conversation_messages.values_mut() {
+            for msg in messages.iter_mut() {
+                if msg.id.as_deref() == Some(msg_id) {
+                    msg.status = status;
+                    return;
+                }
+            }
         }
     }
 }

--- a/crates/chai-cli/src/tui/app.rs
+++ b/crates/chai-cli/src/tui/app.rs
@@ -1,5 +1,6 @@
-//! Application state with typing indicators and read receipts.
+//! Application state with typing indicators, read receipts, and auth.
 
+use crate::auth;
 use crate::config::Config;
 use crate::network::client::Client;
 use anyhow::Result;
@@ -13,6 +14,23 @@ use std::time::{Duration, Instant};
 const TYPING_TIMEOUT: Duration = Duration::from_secs(5);
 /// Debounce interval for sending typing indicators.
 const TYPING_DEBOUNCE: Duration = Duration::from_secs(3);
+
+/// Application screen.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Screen {
+    /// Main chat screen.
+    Chat,
+    /// Welcome/login screen.
+    Welcome,
+    /// Register screen - entering username.
+    Register,
+    /// Mnemonic display screen (after registration).
+    MnemonicDisplay(String),
+    /// Login screen - entering username.
+    Login,
+    /// Mnemonic input screen (for login).
+    MnemonicInput,
+}
 
 /// Input mode for the application.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -77,6 +95,8 @@ struct TypingState {
 pub struct App {
     /// Configuration.
     pub config: Config,
+    /// Current screen.
+    pub screen: Screen,
     /// Current input mode.
     pub input_mode: InputMode,
     /// Current input buffer.
@@ -105,19 +125,30 @@ pub struct App {
     last_typing_sent: Option<Instant>,
     /// Whether we're currently in "typing" state.
     is_typing: bool,
+    /// Username being entered for auth.
+    pub auth_username: String,
+    /// Mnemonic being entered for login.
+    pub auth_mnemonic: String,
+    /// Auth error message.
+    pub auth_error: Option<String>,
+    /// Auth is in progress.
+    pub auth_loading: bool,
 }
 
 impl App {
     pub fn new(config: Config) -> Self {
         let user_id = config.user_id.clone();
-        let status = if config.session_token.is_some() {
-            "Ready to connect. Press ':c' to connect".into()
+        let is_authenticated = config.is_authenticated();
+
+        let (screen, status) = if is_authenticated {
+            (Screen::Chat, "Ready to connect. Press ':c' to connect".into())
         } else {
-            "Not logged in. Use ':login' to sign in".into()
+            (Screen::Welcome, "Welcome to Chai! Press 'r' to register or 'l' to login".into())
         };
 
         Self {
             config,
+            screen,
             input_mode: InputMode::Normal,
             input: String::new(),
             cursor_position: 0,
@@ -132,6 +163,10 @@ impl App {
             typing_states: HashMap::new(),
             last_typing_sent: None,
             is_typing: false,
+            auth_username: String::new(),
+            auth_mnemonic: String::new(),
+            auth_error: None,
+            auth_loading: false,
         }
     }
 
@@ -202,10 +237,150 @@ impl App {
 
     /// Handle a key event.
     pub fn handle_key(&mut self, key: KeyEvent) {
-        match self.input_mode {
-            InputMode::Normal => self.handle_normal_mode(key),
-            InputMode::Editing => self.handle_editing_mode(key),
-            InputMode::Command => self.handle_command_mode(key),
+        // Route based on current screen
+        match &self.screen {
+            Screen::Welcome => self.handle_welcome_key(key),
+            Screen::Register => self.handle_register_key(key),
+            Screen::Login => self.handle_login_key(key),
+            Screen::MnemonicDisplay(_) => self.handle_mnemonic_display_key(key),
+            Screen::MnemonicInput => self.handle_mnemonic_input_key(key),
+            Screen::Chat => {
+                match self.input_mode {
+                    InputMode::Normal => self.handle_normal_mode(key),
+                    InputMode::Editing => self.handle_editing_mode(key),
+                    InputMode::Command => self.handle_command_mode(key),
+                }
+            }
+        }
+    }
+
+    /// Handle key events on welcome screen.
+    fn handle_welcome_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Char('r') | KeyCode::Char('R') => {
+                self.screen = Screen::Register;
+                self.auth_username.clear();
+                self.auth_error = None;
+                self.status = "Enter a username".into();
+            }
+            KeyCode::Char('l') | KeyCode::Char('L') => {
+                self.screen = Screen::Login;
+                self.auth_username.clear();
+                self.auth_error = None;
+                self.status = "Enter your username".into();
+            }
+            _ => {}
+        }
+    }
+
+    /// Handle key events on register screen.
+    fn handle_register_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Esc => {
+                self.screen = Screen::Welcome;
+                self.auth_username.clear();
+                self.auth_error = None;
+            }
+            KeyCode::Enter => {
+                if !self.auth_username.is_empty() {
+                    // Generate mnemonic and proceed
+                    let mnemonic = auth::new_mnemonic();
+                    self.screen = Screen::MnemonicDisplay(mnemonic);
+                    self.status = "Write down your recovery phrase! Press Enter when ready.".into();
+                }
+            }
+            KeyCode::Char(c) => {
+                if c.is_ascii_alphanumeric() || c == '_' {
+                    self.auth_username.push(c);
+                    self.auth_error = None;
+                }
+            }
+            KeyCode::Backspace => {
+                self.auth_username.pop();
+            }
+            _ => {}
+        }
+    }
+
+    /// Handle key events on login screen.
+    fn handle_login_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Esc => {
+                self.screen = Screen::Welcome;
+                self.auth_username.clear();
+                self.auth_error = None;
+            }
+            KeyCode::Enter => {
+                if !self.auth_username.is_empty() {
+                    self.screen = Screen::MnemonicInput;
+                    self.auth_mnemonic.clear();
+                    self.status = "Enter your 24-word recovery phrase".into();
+                }
+            }
+            KeyCode::Char(c) => {
+                if c.is_ascii_alphanumeric() || c == '_' {
+                    self.auth_username.push(c);
+                    self.auth_error = None;
+                }
+            }
+            KeyCode::Backspace => {
+                self.auth_username.pop();
+            }
+            _ => {}
+        }
+    }
+
+    /// Handle key events on mnemonic display screen.
+    fn handle_mnemonic_display_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Esc => {
+                self.screen = Screen::Register;
+                self.status = "Enter a username".into();
+            }
+            KeyCode::Enter => {
+                // User confirmed they saved the mnemonic
+                if let Screen::MnemonicDisplay(mnemonic) = self.screen.clone() {
+                    self.auth_mnemonic = mnemonic;
+                    self.auth_loading = true;
+                    self.status = "Registering...".into();
+                    // Auth will be performed in tick()
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Handle key events on mnemonic input screen.
+    fn handle_mnemonic_input_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Esc => {
+                self.screen = Screen::Login;
+                self.auth_mnemonic.clear();
+                self.auth_error = None;
+                self.status = "Enter your username".into();
+            }
+            KeyCode::Enter => {
+                if !self.auth_mnemonic.is_empty() {
+                    // Validate mnemonic
+                    if auth::is_valid_mnemonic(&self.auth_mnemonic) {
+                        self.auth_loading = true;
+                        self.status = "Logging in...".into();
+                        // Auth will be performed in tick()
+                    } else {
+                        self.auth_error = Some("Invalid recovery phrase".into());
+                    }
+                }
+            }
+            KeyCode::Char(c) => {
+                if c.is_ascii_alphabetic() || c == ' ' {
+                    self.auth_mnemonic.push(c.to_ascii_lowercase());
+                    self.auth_error = None;
+                }
+            }
+            KeyCode::Backspace => {
+                self.auth_mnemonic.pop();
+            }
+            _ => {}
         }
     }
 
@@ -505,13 +680,25 @@ impl App {
                 // Will be handled by main loop
             }
             "connect" | "c" => {
-                self.status = "Connecting...".into();
+                if self.config.is_authenticated() {
+                    self.status = "Connecting...".into();
+                } else {
+                    self.status = "Not logged in. Use :logout to switch accounts".into();
+                }
             }
             "disconnect" | "dc" => {
                 self.disconnect();
             }
+            "logout" => {
+                self.disconnect();
+                self.config.logout();
+                let _ = self.config.save();
+                self.screen = Screen::Welcome;
+                self.status = "Logged out. Press 'r' to register or 'l' to login".into();
+            }
             "help" | "h" => {
-                self.status = ":c connect | :dc disconnect | :chat <user> | :q quit".into();
+                self.status =
+                    ":c connect | :dc disconnect | :chat <user> | :logout | :q quit".into();
             }
             _ if cmd.starts_with("chat ") => {
                 let username = cmd.strip_prefix("chat ").unwrap().trim();
@@ -546,8 +733,14 @@ impl App {
         self.status = format!("Chat with {}", username);
     }
 
-    /// Process network events.
+    /// Process network events and auth.
     pub async fn tick(&mut self) -> Result<()> {
+        // Handle auth if loading
+        if self.auth_loading {
+            self.perform_auth().await;
+            return Ok(());
+        }
+
         // Clean up expired typing indicators
         self.cleanup_typing_indicators();
 
@@ -566,6 +759,55 @@ impl App {
             self.handle_server_message(msg);
         }
         Ok(())
+    }
+
+    /// Perform auth operation.
+    async fn perform_auth(&mut self) {
+        let is_register = matches!(self.screen, Screen::MnemonicDisplay(_));
+
+        let result = if is_register {
+            auth::register_flow(
+                &mut self.config,
+                &self.auth_username,
+                &self.auth_mnemonic,
+            )
+            .await
+        } else {
+            auth::login_flow(
+                &mut self.config,
+                &self.auth_username,
+                &self.auth_mnemonic,
+            )
+            .await
+        };
+
+        self.auth_loading = false;
+
+        match result {
+            Ok(()) => {
+                // Auth succeeded
+                self.user_id = self.config.user_id.clone();
+                self.screen = Screen::Chat;
+                self.auth_username.clear();
+                self.auth_mnemonic.clear();
+                self.auth_error = None;
+                self.status = format!(
+                    "Welcome, {}! Press ':c' to connect",
+                    self.config.username.as_deref().unwrap_or("user")
+                );
+            }
+            Err(e) => {
+                // Auth failed
+                self.auth_error = Some(e.to_string());
+                self.status = "Authentication failed".into();
+                // Go back to appropriate screen
+                if is_register {
+                    self.screen = Screen::Register;
+                } else {
+                    self.screen = Screen::MnemonicInput;
+                }
+            }
+        }
     }
 
     /// Clean up expired typing indicators.

--- a/crates/chai-cli/src/tui/ui.rs
+++ b/crates/chai-cli/src/tui/ui.rs
@@ -1,17 +1,393 @@
 //! UI rendering.
 
-use crate::tui::app::{App, InputMode};
+use crate::tui::app::{App, InputMode, Screen};
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span, Text},
-    widgets::{Block, Borders, List, ListItem, Paragraph},
+    widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
     Frame,
 };
 
 /// Main draw function.
 pub fn draw(f: &mut Frame, app: &App) {
-    // Create main layout
+    match &app.screen {
+        Screen::Welcome => draw_welcome(f, app),
+        Screen::Register => draw_register(f, app),
+        Screen::Login => draw_login(f, app),
+        Screen::MnemonicDisplay(mnemonic) => draw_mnemonic_display(f, app, mnemonic),
+        Screen::MnemonicInput => draw_mnemonic_input(f, app),
+        Screen::Chat => draw_chat(f, app),
+    }
+}
+
+/// Draw welcome/landing screen.
+fn draw_welcome(f: &mut Frame, app: &App) {
+    let area = f.size();
+
+    // Center the content
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(30),
+            Constraint::Length(15),
+            Constraint::Percentage(30),
+        ])
+        .split(area);
+
+    let content_area = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(20),
+            Constraint::Percentage(60),
+            Constraint::Percentage(20),
+        ])
+        .split(chunks[1])[1];
+
+    let text = vec![
+        Line::from(Span::styled(
+            "  ☕ Chai.im",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from("  Secure, end-to-end encrypted messaging"),
+        Line::from(""),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  [R] Register new account",
+            Style::default().fg(Color::Green),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  [L] Login with recovery phrase",
+            Style::default().fg(Color::Cyan),
+        )),
+        Line::from(""),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Press Ctrl+Q to quit",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+
+    let paragraph = Paragraph::new(text)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Yellow))
+                .title(" Welcome "),
+        )
+        .alignment(Alignment::Left);
+
+    f.render_widget(paragraph, content_area);
+
+    // Status at bottom
+    draw_status_bar(f, app, area);
+}
+
+/// Draw registration screen.
+fn draw_register(f: &mut Frame, app: &App) {
+    let area = f.size();
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(30),
+            Constraint::Length(10),
+            Constraint::Percentage(30),
+        ])
+        .split(area);
+
+    let content_area = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(20),
+            Constraint::Percentage(60),
+            Constraint::Percentage(20),
+        ])
+        .split(chunks[1])[1];
+
+    let mut text = vec![
+        Line::from(Span::styled(
+            "  Create Account",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from("  Choose a username (alphanumeric + underscore):"),
+        Line::from(""),
+        Line::from(format!("  > {}_", app.auth_username)),
+        Line::from(""),
+    ];
+
+    if let Some(error) = &app.auth_error {
+        text.push(Line::from(Span::styled(
+            format!("  Error: {}", error),
+            Style::default().fg(Color::Red),
+        )));
+    } else {
+        text.push(Line::from(Span::styled(
+            "  Press Enter to continue, ESC to go back",
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    let paragraph = Paragraph::new(text)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Green))
+                .title(" Register "),
+        )
+        .alignment(Alignment::Left);
+
+    f.render_widget(paragraph, content_area);
+    draw_status_bar(f, app, area);
+
+    // Set cursor position
+    f.set_cursor(
+        content_area.x + 5 + app.auth_username.len() as u16,
+        content_area.y + 5,
+    );
+}
+
+/// Draw login screen.
+fn draw_login(f: &mut Frame, app: &App) {
+    let area = f.size();
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(30),
+            Constraint::Length(10),
+            Constraint::Percentage(30),
+        ])
+        .split(area);
+
+    let content_area = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(20),
+            Constraint::Percentage(60),
+            Constraint::Percentage(20),
+        ])
+        .split(chunks[1])[1];
+
+    let mut text = vec![
+        Line::from(Span::styled(
+            "  Login",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from("  Enter your username:"),
+        Line::from(""),
+        Line::from(format!("  > {}_", app.auth_username)),
+        Line::from(""),
+    ];
+
+    if let Some(error) = &app.auth_error {
+        text.push(Line::from(Span::styled(
+            format!("  Error: {}", error),
+            Style::default().fg(Color::Red),
+        )));
+    } else {
+        text.push(Line::from(Span::styled(
+            "  Press Enter to continue, ESC to go back",
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    let paragraph = Paragraph::new(text)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan))
+                .title(" Login "),
+        )
+        .alignment(Alignment::Left);
+
+    f.render_widget(paragraph, content_area);
+    draw_status_bar(f, app, area);
+
+    f.set_cursor(
+        content_area.x + 5 + app.auth_username.len() as u16,
+        content_area.y + 5,
+    );
+}
+
+/// Draw mnemonic display screen.
+fn draw_mnemonic_display(f: &mut Frame, app: &App, mnemonic: &str) {
+    let area = f.size();
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(15),
+            Constraint::Length(20),
+            Constraint::Percentage(15),
+        ])
+        .split(area);
+
+    let content_area = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(10),
+            Constraint::Percentage(80),
+            Constraint::Percentage(10),
+        ])
+        .split(chunks[1])[1];
+
+    // Format mnemonic as numbered grid
+    let words: Vec<&str> = mnemonic.split_whitespace().collect();
+    let mut mnemonic_lines = vec![
+        Line::from(Span::styled(
+            "  Your Recovery Phrase",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  ⚠️  Write these words down and keep them safe!",
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(Span::styled(
+            "  Anyone with this phrase can access your account.",
+            Style::default().fg(Color::Red),
+        )),
+        Line::from(""),
+    ];
+
+    // Display words in 4 columns of 6
+    for row in 0..6 {
+        let mut line_spans = vec![Span::raw("  ")];
+        for col in 0..4 {
+            let idx = row + col * 6;
+            if idx < words.len() {
+                let word_text = format!("{:>2}. {:<12}", idx + 1, words[idx]);
+                line_spans.push(Span::styled(
+                    word_text,
+                    Style::default().fg(Color::Green),
+                ));
+            }
+        }
+        mnemonic_lines.push(Line::from(line_spans));
+    }
+
+    mnemonic_lines.push(Line::from(""));
+
+    if app.auth_loading {
+        mnemonic_lines.push(Line::from(Span::styled(
+            "  Registering...",
+            Style::default().fg(Color::Yellow),
+        )));
+    } else {
+        mnemonic_lines.push(Line::from(Span::styled(
+            "  Press Enter when you've saved your phrase",
+            Style::default().fg(Color::Cyan),
+        )));
+    }
+
+    let paragraph = Paragraph::new(mnemonic_lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Yellow))
+                .title(" Recovery Phrase "),
+        )
+        .alignment(Alignment::Left);
+
+    f.render_widget(paragraph, content_area);
+    draw_status_bar(f, app, area);
+}
+
+/// Draw mnemonic input screen.
+fn draw_mnemonic_input(f: &mut Frame, app: &App) {
+    let area = f.size();
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(20),
+            Constraint::Length(14),
+            Constraint::Percentage(20),
+        ])
+        .split(area);
+
+    let content_area = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(10),
+            Constraint::Percentage(80),
+            Constraint::Percentage(10),
+        ])
+        .split(chunks[1])[1];
+
+    let word_count = app.auth_mnemonic.split_whitespace().count();
+
+    let mut text = vec![
+        Line::from(Span::styled(
+            "  Enter Recovery Phrase",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(format!("  Words entered: {}/24", word_count)),
+        Line::from(""),
+    ];
+
+    // Show entered words wrapped
+    let display_text = if app.auth_mnemonic.is_empty() {
+        "Type your 24-word recovery phrase...".to_string()
+    } else {
+        app.auth_mnemonic.clone()
+    };
+
+    text.push(Line::from(Span::styled(
+        format!("  {}", display_text),
+        Style::default().fg(Color::Green),
+    )));
+    text.push(Line::from(""));
+
+    if let Some(error) = &app.auth_error {
+        text.push(Line::from(Span::styled(
+            format!("  Error: {}", error),
+            Style::default().fg(Color::Red),
+        )));
+    } else if app.auth_loading {
+        text.push(Line::from(Span::styled(
+            "  Logging in...",
+            Style::default().fg(Color::Yellow),
+        )));
+    } else {
+        text.push(Line::from(Span::styled(
+            "  Separate words with spaces. Press Enter when done.",
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    let paragraph = Paragraph::new(text)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan))
+                .title(" Recovery Phrase "),
+        )
+        .wrap(Wrap { trim: false })
+        .alignment(Alignment::Left);
+
+    f.render_widget(paragraph, content_area);
+    draw_status_bar(f, app, area);
+}
+
+/// Draw main chat screen.
+fn draw_chat(f: &mut Frame, app: &App) {
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
@@ -34,8 +410,9 @@ fn draw_sidebar(f: &mut Frame, app: &App, area: Rect) {
         ])
         .split(area);
 
-    // Header
-    let header = Paragraph::new("  Chai.im")
+    // Header with username
+    let username = app.config.username.as_deref().unwrap_or("Anonymous");
+    let header = Paragraph::new(format!("  ☕ {} ", username))
         .style(
             Style::default()
                 .fg(Color::Yellow)
@@ -57,13 +434,17 @@ fn draw_sidebar(f: &mut Frame, app: &App, area: Rect) {
             };
 
             let online_indicator = if conv.online { "●" } else { "○" };
+            let typing_indicator = if conv.typing { " ..." } else { "" };
             let unread = if conv.unread_count > 0 {
                 format!(" ({})", conv.unread_count)
             } else {
                 String::new()
             };
 
-            let content = format!("{} {}{}", online_indicator, conv.name, unread);
+            let content = format!(
+                "{} {}{}{}",
+                online_indicator, conv.name, typing_indicator, unread
+            );
             ListItem::new(content).style(style)
         })
         .collect();
@@ -96,8 +477,15 @@ fn draw_chat_area(f: &mut Frame, app: &App, area: Rect) {
     // Chat header
     let current_conv = app.conversations.get(app.selected_conversation);
     let header_title = current_conv
-        .map(|c| c.name.as_str())
-        .unwrap_or("No conversation selected");
+        .map(|c| {
+            if c.typing {
+                format!("{} (typing...)", c.name)
+            } else {
+                c.name.clone()
+            }
+        })
+        .unwrap_or_else(|| "No conversation selected".to_string());
+
     let header = Paragraph::new(header_title)
         .style(Style::default().add_modifier(Modifier::BOLD))
         .block(Block::default().borders(Borders::ALL));
@@ -121,7 +509,13 @@ fn draw_messages(f: &mut Frame, app: &App, area: Rect) {
                 Style::default().fg(Color::White)
             };
 
-            let header = format!("{} [{}]", msg.sender, msg.timestamp);
+            let status_icon = if msg.is_self {
+                format!(" {}", msg.status.icon())
+            } else {
+                String::new()
+            };
+
+            let header = format!("{} [{}]{}", msg.sender, msg.timestamp, status_icon);
             let content = render_message_content(&msg.content);
 
             let lines: Vec<Line> = std::iter::once(Line::from(Span::styled(
@@ -207,4 +601,18 @@ fn draw_input(f: &mut Frame, app: &App, area: Rect) {
             area.y + 1,
         );
     }
+}
+
+/// Draw status bar at bottom of screen.
+fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(1)])
+        .split(area);
+
+    let status = Paragraph::new(app.status.as_str())
+        .style(Style::default().fg(Color::DarkGray))
+        .alignment(Alignment::Center);
+
+    f.render_widget(status, chunks[1]);
 }


### PR DESCRIPTION
## Summary

Complete identity key authentication flow for the CLI terminal client.

### New Features

**Auth Module (`auth.rs`)**
- HTTP client for identity auth endpoints
- BIP39 mnemonic generation (24 words)
- Ed25519 signature for challenge-response
- Register and login flows

**TUI Auth Screens**
- **Welcome** - Press R to register, L to login
- **Register** - Enter username, get recovery phrase
- **Mnemonic Display** - 24-word grid (4 columns × 6 rows)
- **Login** - Enter username, then recovery phrase
- **Mnemonic Input** - Type 24 words with word counter

**Config Updates**
- `identity_key` - Base64-encoded Ed25519 private key
- `ws_url` - Separate WebSocket URL
- `is_authenticated()` - Check auth state
- `logout()` - Clear all auth data

**Commands**
- `:logout` - Sign out and return to welcome screen
- `:help` - Updated with logout command

### Dependencies Added
- `reqwest` (rustls-tls) - HTTP client
- `base64` - Key encoding

## Test Plan
- [ ] Register new account, verify mnemonic is shown
- [ ] Write down mnemonic, complete registration
- [ ] Logout and login with saved mnemonic
- [ ] Verify config file stores identity key
